### PR TITLE
Add LTI error route

### DIFF
--- a/server.lti.cjs
+++ b/server.lti.cjs
@@ -9,6 +9,7 @@ const LTI = require('ltijs');
 const helmet = require('helmet');
 const cors = require('cors');
 const rateLimit = require('express-rate-limit');
+const path = require('path');
 require('dotenv').config();
 
 const logger = {
@@ -243,6 +244,18 @@ const PORT = process.env.PORT || 3002;
     });
     logger.info('LTI-provider succesvol gedeployed!');
     app.use(lti.app);
+
+    const distPath = path.join(__dirname, 'dist');
+    app.use(express.static(distPath));
+
+    app.get('/lti-error', (req, res) => {
+      res.sendFile(path.join(distPath, 'index.html'));
+    });
+
+    app.get('*', (req, res) => {
+      res.sendFile(path.join(distPath, 'index.html'));
+    });
+
     app.listen(PORT, () => {
       console.log(`Express hoofd-app draait op poort ${PORT}`);
     });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import LTIErrorPage from "@/pages/LTIErrorPage";
 
 import DevTools from "@/components/dev/DevTools";
 import { ThemeSwitcher } from "@/components/ui/theme-switcher";
@@ -28,6 +29,7 @@ function App() {
               <Route path="/question-types" element={<Navigate to="/" replace />} />
               <Route path="/editor" element={<Editor />} />
               <Route path="/scorm" element={<ScormPage />} />
+              <Route path="/lti-error" element={<LTIErrorPage />} />
               <Route path="/ai-generator" element={<Navigate to="/" replace />} />
               <Route path="/multiple-choice-test" element={<Navigate to="/" replace />} />
             </Routes>


### PR DESCRIPTION
## Summary
- add `<Route path='/lti-error'>` to React router
- serve React app from Express with a catch-all route and dedicated `/lti-error` handler

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688735069094832788ca192ef84e92ca