### PR TITLE
Switch LTI provider to ltijs-sequelize

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,7 @@ DEBUG=false Voorbeeld .env voor LTI 1.3 integratie (NIET committen naar git!)
 LTI_KEY=your-lti-client-id
 LTI_SECRET=your-lti-client-secret
 LTI_URL=https://your-ngrok-url.ngrok.io
-LTI_DATABASE_URL=file:./database.sqlite
+LTI_DATABASE_PATH=./database.sqlite
 SESSION_SECRET=some-random-secret
 
 # LTI 1.3 Configuration (LTI Integration with Moodle)

--- a/docs/LTI-SETUP.md
+++ b/docs/LTI-SETUP.md
@@ -18,6 +18,7 @@ LTI_DEPLOYMENT_ID=your-deployment-id
 MOODLE_URL=https://your-moodle-instance.com
 BASE_URL=https://your-ngrok-url.ngrok.io
 FRONTEND_URL=https://your-ngrok-url.ngrok.io
+LTI_DATABASE_PATH=./database.sqlite
 
 # Security
 JWT_SECRET=your-jwt-secret-key
@@ -78,6 +79,7 @@ LTI_DEPLOYMENT_ID=deployment-1
 MOODLE_URL=https://your-moodle-instance.com
 BASE_URL=https://your-ngrok-url.ngrok.io
 FRONTEND_URL=https://your-ngrok-url.ngrok.io
+LTI_DATABASE_PATH=./database.sqlite
 
 # Security
 JWT_SECRET=your-super-secret-jwt-key


### PR DESCRIPTION
## Summary
- use `ltijs-sequelize` plugin for the LTI provider
- update environment variable to `LTI_DATABASE_PATH`
- document new variable in LTI setup guide

## Testing
- `npx vitest run` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688734f598408327840b9b8a43325f3f