### PR TITLE
Fix LTI database connection

### DIFF
--- a/server.lti.cjs
+++ b/server.lti.cjs
@@ -31,11 +31,11 @@ app.use(session({
 app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ extended: true, limit: '50mb' }));
 
-// Database configuratie - CORRECTE SYNTAX
-const db = new Database({
+// Database configuratie
+const dbUrl = process.env.LTI_DATABASE_URL || 'sqlite://./database.sqlite';
+const db = new Database(dbUrl, {
   dialect: 'sqlite',
-  storage: './database.sqlite',
-  logging: false
+  logging: false,
 });
 
 // LTI setup


### PR DESCRIPTION
## Summary
- update LTI server DB initialization to use connection string
- allow configuration via `LTI_DATABASE_URL` env var

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688763c21c80832797d7132975327616