### PR TITLE
Document Node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# SCORM Wizard
+
+This project is tested with Node.js versions 18 through 21. Ensure your environment uses a Node version that satisfies `>=18 <22`.
+
+Vercel deployments automatically use the version defined in the `engines` field of `package.json`.
+
+See [docs/README-SERVER-USAGE.md](docs/README-SERVER-USAGE.md) for usage instructions.
+

--- a/docs/README-SERVER-USAGE.md
+++ b/docs/README-SERVER-USAGE.md
@@ -2,6 +2,10 @@
 
 Deze handleiding legt uit hoe je de SCORM Wizard server kunt starten en beheren zonder dat je hoofdterminal geblokkeerd wordt.
 
+## Systeemvereisten
+
+Deze applicatie is getest met Node.js versies 18 tot en met 21. Zorg dat je een Node versie gebruikt die voldoet aan `>=18 <22` om compatibiliteitsproblemen te voorkomen.
+
 ## Inhoudsopgave
 
 1. [Server starten](#server-starten)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=18 <22"
+  },
   "scripts": {
     "dev": "vite",
     "dev:server": "concurrently \"node server.cjs\" \"vite\"",


### PR DESCRIPTION
## Summary
- specify supported Node version in package.json
- add compatibility note to README-SERVER-USAGE
- add root README mentioning Node version and Vercel behavior

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887650244588327a16026b1ff460164