### PR TITLE
Switch to SQLite session store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ CSRF_SECRET=your_csrf_secret_here
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100
 SESSION_SECRET=your_session_secret_here
+# Session store
+SESSION_DB_FILE=sessions.sqlite
+SESSION_DB_DIR=./db
 
 # Monitoring
 HEALTH_CHECK_INTERVAL=30000

--- a/docs/LTI_STAPPENPLAN.md
+++ b/docs/LTI_STAPPENPLAN.md
@@ -5,7 +5,7 @@ Dit plan is gericht op een solo-project, proof-of-concept of kleine pilot. Allee
 ---
 
 ## 1. Voorbereiding
-- [✅] **Installeer ltijs**: `npm install ltijs express-session`
+- [✅] **Installeer ltijs**: `npm install ltijs express-session connect-sqlite3`
 - [✅] **.env**: Zet secrets (client secret, db-url) in `.env` (niet in git)
 - [✅] **HTTPS via ngrok**: Start je backend met `ngrok http 3002` (LTI 1.3 vereist HTTPS)
 https://19cc-178-224-10-53.ngrok-free.app  →  http://localhost:3002

--- a/docs/README-SERVER-USAGE.md
+++ b/docs/README-SERVER-USAGE.md
@@ -117,6 +117,17 @@ Maak een `.env` bestand in de hoofdmap van het project met:
 OPENAI_API_KEY=jouw_api_sleutel_hier
 ```
 
+### Session database configuratie
+
+Voor productie gebruikt de server nu een SQLite sessiestore.
+Voeg de volgende variabelen toe aan je `.env`:
+
+```
+SESSION_DB_FILE=sessions.sqlite
+SESSION_DB_DIR=./db
+```
+Installeer ook de dependency `connect-sqlite3` met `npm install connect-sqlite3`.
+
 ### Kan ik de server in een Docker container draaien?
 
 Momenteel is Docker-ondersteuning niet geïmplementeerd. Je kunt de servers alleen lokaal draaien.

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "cmdk": "^1.0.0",
     "concurrently": "^8.2.2",
     "cors": "^2.8.5",
+    "connect-sqlite3": "^0.9.0",
     "date-fns": "^3.6.0",
     "dotenv": "^16.4.7",
     "embla-carousel-react": "^8.3.0",

--- a/server.lti.cjs
+++ b/server.lti.cjs
@@ -1,5 +1,6 @@
 const express = require('express');
 const session = require('express-session');
+const SQLiteStore = require('connect-sqlite3')(session);
 const cors = require('cors');
 const path = require('path');
 const { Provider } = require('ltijs');
@@ -16,7 +17,11 @@ app.use(cors({
 }));
 
 // Session configuratie
-app.use(session({
+const sessionOptions = {
+  store: new SQLiteStore({
+    db: process.env.SESSION_DB_FILE || 'sessions.sqlite',
+    dir: process.env.SESSION_DB_DIR || './db'
+  }),
   secret: process.env.LTI_KEY || 'your-lti-key-here',
   resave: false,
   saveUninitialized: false,
@@ -25,7 +30,9 @@ app.use(session({
     httpOnly: true,
     maxAge: 24 * 60 * 60 * 1000
   }
-}));
+};
+
+app.use(session(sessionOptions));
 
 // Express middleware
 app.use(express.json({ limit: '50mb' }));


### PR DESCRIPTION
## Summary
- use `connect-sqlite3` for Express sessions in `server.lti.cjs`
- expose `SESSION_DB_FILE` and `SESSION_DB_DIR` in `.env.example`
- document new session store dependency and configuration
- mention `connect-sqlite3` in the LTI setup guide

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688764f98c308327aaaca61d031427de