### PR TITLE
Fix LTI provider setup

### DIFF
--- a/server.lti.cjs
+++ b/server.lti.cjs
@@ -3,7 +3,7 @@ const express = require('express');
 const session = require('express-session');
 const cors = require('cors');
 const path = require('path');
-const { Provider } = require('ltijs');
+const lti = require('ltijs').Provider;
 const Database = require('ltijs-sequelize');
 const SQLiteStore = require('connect-sqlite3')(session);
 const { Sequelize } = require('sequelize');
@@ -161,7 +161,7 @@ console.log('[INFO] LTI Key:', process.env.LTI_KEY);
 console.log('[INFO] LTI Database URL:', process.env.LTI_DATABASE_URL);
 console.log('[INFO] NODE_ENV:', process.env.NODE_ENV);
 
-const lti = new Provider(
+lti.setup(
   process.env.LTI_KEY,
   ltiDatabaseConfig,
   {


### PR DESCRIPTION
## Summary
- import Provider as `lti` and configure via `lti.setup`
- remove old `new Provider` instantiation

## Testing
- `npm test` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*
- `node server.lti.cjs` *(fails: invalid ELF header for sqlite3)*

------
https://chatgpt.com/codex/tasks/task_e_68897c3de6308327bce74f435b7a5256